### PR TITLE
Create UTM link builder single-page app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UTM Link Planner & Builder</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <header>
+      <h1>UTM Link Planner & Builder</h1>
+      <p>Create, copy, and manage UTM-tracked URLs with ease.</p>
+    </header>
+
+    <section class="builder">
+      <form id="utm-form" class="utm-form">
+        <label class="field">
+          <span>Destination URL</span>
+          <input type="url" id="url" name="url" placeholder="https://example.com" required />
+        </label>
+        <div class="field-group">
+          <label class="field">
+            <span>UTM Source</span>
+            <select id="utm-source" name="utm-source" required>
+              <option value="">Select Source</option>
+              <option value="google">Google</option>
+              <option value="facebook">Facebook</option>
+              <option value="newsletter">Newsletter</option>
+              <option value="linkedin">LinkedIn</option>
+              <option value="twitter">Twitter</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>UTM Medium</span>
+            <select id="utm-medium" name="utm-medium" required>
+              <option value="">Select Medium</option>
+              <option value="cpc">CPC</option>
+              <option value="email">Email</option>
+              <option value="social">Social</option>
+              <option value="referral">Referral</option>
+              <option value="display">Display</option>
+            </select>
+          </label>
+        </div>
+        <div class="field-group">
+          <label class="field flex">
+            <span>UTM Campaign</span>
+            <input type="text" id="utm-campaign" name="utm-campaign" placeholder="spring_launch" required />
+          </label>
+          <button type="submit" class="primary">Create UTM Link</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="links">
+      <h2>Generated UTM Links</h2>
+      <p class="empty" id="empty-state">No UTM links yet. Create one to get started.</p>
+      <div class="link-lists" id="link-lists">
+        <div class="link-list" id="active-links" data-title="Active"></div>
+        <div class="link-list" id="archived-links" data-title="Archived"></div>
+      </div>
+    </section>
+  </main>
+
+  <div id="context-menu" class="context-menu" hidden>
+    <button type="button" data-action="copy">Copy</button>
+    <button type="button" data-action="archive">Archive</button>
+    <button type="button" data-action="delete">Delete</button>
+  </div>
+
+  <div id="toast" class="toast" hidden></div>
+
+  <template id="link-template">
+    <article class="link-item" tabindex="0">
+      <header>
+        <p class="link-url"></p>
+        <time></time>
+      </header>
+      <footer>
+        <span class="badge source"></span>
+        <span class="badge medium"></span>
+        <span class="badge campaign"></span>
+      </footer>
+    </article>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,326 @@
+const form = document.getElementById('utm-form');
+const urlInput = document.getElementById('url');
+const sourceSelect = document.getElementById('utm-source');
+const mediumSelect = document.getElementById('utm-medium');
+const campaignInput = document.getElementById('utm-campaign');
+const activeContainer = document.getElementById('active-links');
+const archivedContainer = document.getElementById('archived-links');
+const emptyState = document.getElementById('empty-state');
+const template = document.getElementById('link-template');
+const contextMenu = document.getElementById('context-menu');
+const toast = document.getElementById('toast');
+
+let utmLinks = loadLinks();
+let contextTargetId = null;
+
+render();
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+
+  if (!form.checkValidity()) {
+    form.reportValidity();
+    return;
+  }
+
+  const baseUrl = urlInput.value.trim();
+  const utmSource = sourceSelect.value.trim();
+  const utmMedium = mediumSelect.value.trim();
+  const rawCampaign = campaignInput.value;
+  const utmCampaign = normalizeCampaign(rawCampaign);
+  if (!utmCampaign) {
+    showToast('Please provide a campaign name using letters or numbers.');
+    campaignInput.focus();
+    return;
+  }
+
+  const utmUrl = buildUtmUrl(baseUrl, {
+    utm_source: utmSource,
+    utm_medium: utmMedium,
+    utm_campaign: utmCampaign,
+  });
+
+  const link = {
+    id: createId(),
+    baseUrl,
+    utmSource,
+    utmMedium,
+    utmCampaign,
+    utmUrl,
+    createdAt: Date.now(),
+    archived: false,
+  };
+
+  utmLinks.unshift(link);
+  saveLinks();
+  render();
+  form.reset();
+  urlInput.focus();
+  notifyCopy(utmUrl, 'UTM link created and copied to clipboard!');
+});
+
+function buildUtmUrl(baseUrl, params) {
+  try {
+    const url = new URL(baseUrl);
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+    return url.toString();
+  } catch (error) {
+    // If the URL constructor fails, attempt to prepend https://
+    const prefixed = /^https?:\/\//i.test(baseUrl)
+      ? baseUrl
+      : `https://${baseUrl}`;
+    return buildUtmUrl(prefixed, params);
+  }
+}
+
+function createId() {
+  if (crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  const array = crypto.getRandomValues(new Uint32Array(4));
+  return Array.from(array, (segment) => segment.toString(16).padStart(8, '0')).join('-');
+}
+
+function normalizeCampaign(value) {
+  return value
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_\-]/gi, '')
+    .toLowerCase();
+}
+
+function loadLinks() {
+  try {
+    const raw = localStorage.getItem('utm-links');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.sort((a, b) => b.createdAt - a.createdAt);
+  } catch (error) {
+    console.error('Failed to load saved links', error);
+    return [];
+  }
+}
+
+function saveLinks() {
+  try {
+    localStorage.setItem('utm-links', JSON.stringify(utmLinks));
+  } catch (error) {
+    console.error('Failed to save links', error);
+    showToast('Unable to save links locally.');
+  }
+}
+
+function render() {
+  const active = utmLinks.filter((link) => !link.archived);
+  const archived = utmLinks.filter((link) => link.archived);
+
+  emptyState.hidden = utmLinks.length > 0;
+
+  populateList(activeContainer, active);
+  populateList(archivedContainer, archived);
+}
+
+function populateList(container, list) {
+  container.innerHTML = '';
+
+  list
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .forEach((link) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      node.dataset.id = link.id;
+      node.querySelector('.link-url').textContent = link.utmUrl;
+      node.querySelector('time').textContent = formatDate(link.createdAt);
+      node.querySelector('.badge.source').textContent = `Source: ${link.utmSource}`;
+      node.querySelector('.badge.medium').textContent = `Medium: ${link.utmMedium}`;
+      node.querySelector(
+        '.badge.campaign'
+      ).textContent = `Campaign: ${link.utmCampaign}`;
+
+      container.appendChild(node);
+    });
+
+  container.toggleAttribute('hidden', list.length === 0);
+}
+
+function formatDate(timestamp) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(timestamp));
+}
+
+function copyToClipboard(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return Promise.resolve();
+}
+
+function showToast(message, duration = 2200) {
+  toast.textContent = message;
+  toast.hidden = false;
+  toast.classList.add('visible');
+  if (showToast.timeoutId) {
+    clearTimeout(showToast.timeoutId);
+  }
+  showToast.timeoutId = setTimeout(() => {
+    toast.classList.remove('visible');
+    toast.addEventListener(
+      'transitionend',
+      () => {
+        toast.hidden = true;
+      },
+      { once: true }
+    );
+  }, duration);
+}
+
+function notifyCopy(text, successMessage) {
+  copyToClipboard(text)
+    .then(() => showToast(successMessage))
+    .catch(() =>
+      showToast('Unable to copy automatically. Please copy it manually.')
+    );
+}
+
+function hideContextMenu() {
+  contextMenu.hidden = true;
+  contextTargetId = null;
+}
+
+function getLinkById(id) {
+  return utmLinks.find((link) => link.id === id);
+}
+
+function updateContextMenuForLink(link) {
+  const archiveButton = contextMenu.querySelector('[data-action="archive"]');
+  if (link.archived) {
+    archiveButton.textContent = 'Unarchive';
+  } else {
+    archiveButton.textContent = 'Archive';
+  }
+}
+
+function toggleArchive(id) {
+  utmLinks = utmLinks.map((link) =>
+    link.id === id ? { ...link, archived: !link.archived } : link
+  );
+  saveLinks();
+  render();
+}
+
+function deleteLink(id) {
+  utmLinks = utmLinks.filter((link) => link.id !== id);
+  saveLinks();
+  render();
+}
+
+function handleCopy(link) {
+  notifyCopy(link.utmUrl, 'UTM link copied to clipboard!');
+}
+
+function handleContextAction(action) {
+  if (!contextTargetId) return;
+  const link = getLinkById(contextTargetId);
+  if (!link) return;
+
+  switch (action) {
+    case 'copy':
+      handleCopy(link);
+      break;
+    case 'archive':
+      toggleArchive(link.id);
+      break;
+    case 'delete':
+      deleteLink(link.id);
+      showToast('UTM link deleted.');
+      break;
+    default:
+      break;
+  }
+}
+
+activeContainer.addEventListener('click', (event) => {
+  const item = event.target.closest('.link-item');
+  if (!item) return;
+  const link = getLinkById(item.dataset.id);
+  if (!link) return;
+  handleCopy(link);
+});
+
+archivedContainer.addEventListener('click', (event) => {
+  const item = event.target.closest('.link-item');
+  if (!item) return;
+  const link = getLinkById(item.dataset.id);
+  if (!link) return;
+  handleCopy(link);
+});
+
+[activeContainer, archivedContainer].forEach((container) => {
+  container.addEventListener('contextmenu', (event) => {
+    const item = event.target.closest('.link-item');
+    if (!item) return;
+    event.preventDefault();
+    const link = getLinkById(item.dataset.id);
+    if (!link) return;
+
+    contextTargetId = link.id;
+    updateContextMenuForLink(link);
+    contextMenu.hidden = false;
+    const pointerPadding = 8;
+    const { innerWidth, innerHeight } = window;
+    const menuRect = contextMenu.getBoundingClientRect();
+    const x = Math.min(
+      event.clientX,
+      innerWidth - menuRect.width - pointerPadding
+    );
+    const y = Math.min(
+      event.clientY,
+      innerHeight - menuRect.height - pointerPadding
+    );
+    contextMenu.style.left = `${x}px`;
+    contextMenu.style.top = `${y}px`;
+  });
+});
+
+contextMenu.addEventListener('click', (event) => {
+  const action = event.target.closest('button')?.dataset.action;
+  if (!action) return;
+  handleContextAction(action);
+  hideContextMenu();
+});
+
+document.addEventListener('click', (event) => {
+  if (!contextMenu.hidden && !contextMenu.contains(event.target)) {
+    hideContextMenu();
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !contextMenu.hidden) {
+    hideContextMenu();
+  }
+});
+
+document.addEventListener('scroll', () => {
+  if (!contextMenu.hidden) hideContextMenu();
+});
+
+window.addEventListener('blur', hideContextMenu);
+window.addEventListener('resize', hideContextMenu);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,288 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --card: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --border: rgba(148, 163, 184, 0.3);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1d1f30, #05060f 50%, #02030b);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main.app {
+  width: min(960px, 100%);
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.6);
+}
+
+header > h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+}
+
+header > p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  max-width: 46ch;
+}
+
+section.builder {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  padding: 2rem;
+}
+
+.utm-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.field span {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.field-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.field.flex {
+  flex: 1;
+}
+
+button.primary {
+  padding: 0.9rem 1.6rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  align-self: flex-end;
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+}
+
+section.links {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+section.links h2 {
+  margin: 0;
+}
+
+#empty-state {
+  margin: 0;
+  color: var(--muted);
+}
+
+.link-lists {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.link-list::before {
+  content: attr(data-title);
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+.link-item {
+  position: relative;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.link-item:hover,
+.link-item:focus-visible {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.link-item header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.link-item .link-url {
+  margin: 0;
+  word-break: break-all;
+  font-size: 1rem;
+}
+
+.link-item time {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.link-item footer {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--accent);
+}
+
+.context-menu {
+  position: fixed;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.25rem;
+  min-width: 150px;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.6);
+  z-index: 1000;
+}
+
+.context-menu[hidden] {
+  display: none;
+}
+
+.context-menu button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.context-menu button:hover,
+.context-menu button:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--text);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.9rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+  z-index: 999;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  main.app {
+    padding: 1.5rem;
+  }
+
+  .field-group {
+    flex-direction: column;
+  }
+
+  button.primary {
+    width: 100%;
+  }
+
+  .toast {
+    left: 50%;
+    right: auto;
+    transform: translate(-50%, 20px);
+    width: calc(100% - 2rem);
+    text-align: center;
+  }
+
+  .toast.visible {
+    transform: translate(-50%, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page UTM planner UI with inputs for the destination URL and UTM parameters.
- add persistent storage and management actions for generated links, including copy, archive, unarchive, and delete options.
- implement contextual copy/management menu, toast notifications, and responsive styling.

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e420d7e3208332a3f5b585c2532dc1